### PR TITLE
update syntax of form_for to rails 3.2.8. Fix "message cannot be replied by Admin"

### DIFF
--- a/app/views/messages/show.html.haml
+++ b/app/views/messages/show.html.haml
@@ -6,7 +6,7 @@
   .body= simple_format(@message.body)
 
 %h3 Your reply:
-= form_for 'r_message', nil, :url => { :action => 'reply'} do |f|
+= form_for 'r_message', :url => { :action => 'reply'} do |f|
   = f.text_area :body, :rows => 5, :cols => 100
   = f.hidden_field :receiver_id, {:value => @message.sender_id }
   = f.hidden_field :replying_message_id, {:value => @message.id }


### PR DESCRIPTION
There are two more locations where form_for seem like a bug, they are in 'app/views/site/login.html.haml' However, I does not have a mean to test it. (Dunno how to use site)

(grafted from 17d48b004affe1e1dd4a981d9beef9d61ce83078)

--HG--
extra : source : 17d48b004affe1e1dd4a981d9beef9d61ce83078
