### PR TITLE
let testdata importer set the full score

### DIFF
--- a/lib/testdata_importer.rb
+++ b/lib/testdata_importer.rb
@@ -34,6 +34,7 @@ class TestdataImporter
 
     @log_msg << import_problem_description(dirname)
     @log_msg << import_problem_pdf(dirname)
+    @log_msg << import_full_score(dirname)
 
     return true
   end
@@ -167,6 +168,16 @@ class TestdataImporter
     else
       return ""
     end
+  end
+
+  #just set the full score to the total number of test case
+  #it is not perfect but works on most normal use case
+  def import_full_score(dirname)
+    in_file = Dir["#{dirname}/*.in"]
+    full_score =in_file.length * 10 
+    @problem.full_score = full_score
+    @problem.save
+    return "\nFull score is set to #{full_score}."
   end
 
 end


### PR DESCRIPTION
should work on most of our use cases???

1a.in
1b.in
2a.in
2b.in
2c.in

full score is 50

It won't work when we have to rescale, e.g., when we want 1_.in is 25% and 2_.in is 75%, but I still can't decide what is the best way to accommodate such use cases on the web interface.
