### PR TITLE
add option to update PDF file of a problem in /problem/edit/:id

### DIFF
--- a/app/views/problems/_form.html.erb
+++ b/app/views/problems/_form.html.erb
@@ -48,5 +48,7 @@
 <p><label for="problem_url">URL</label><br/>
 <%= text_field 'problem', 'url'  %></p>
 
+<p>Task PDF <%= file_field_tag 'file' %></p>
+
 
 <!--[eoform:problem]-->

--- a/app/views/problems/edit.html.erb
+++ b/app/views/problems/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing problem</h1>
 
-<%= form_tag :action => 'update', :id => @problem do %>
+<%= form_tag({action: 'update', id: @problem},multipart: true) do %>
   <%= render :partial => 'form' %>
   <%= submit_tag 'Edit' %>
 <% end %>


### PR DESCRIPTION
This allows us to upload only the PDF file to the available task without uploading all the testdata file.

(grafted from 15b2554bf365f8639b5e94db4f1d9a277007808a)

--HG--
extra : source : 15b2554bf365f8639b5e94db4f1d9a277007808a
